### PR TITLE
/stroies へのリンクを修正

### DIFF
--- a/src/templates/index-page.tsx
+++ b/src/templates/index-page.tsx
@@ -77,7 +77,7 @@ export const IndexPageTemplate = ({
                 </h1>
                 <BlogRoll />
                 <div className="column is-12 has-text-centered josefin">
-                  <Link className="btn" to="/blog">
+                  <Link className="btn" to="/stories">
                     More Stories
                   </Link>
                 </div>


### PR DESCRIPTION
/stroies へのリンクを置くべきところが /blog になっているので修正